### PR TITLE
Remove comment with cran-server language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 sudo: false
- # Currently, cran-server only works on python 3.6
 matrix:
   include:
       - os: linux


### PR DESCRIPTION
We should remove this language about cran-server from `.travis.yml`